### PR TITLE
Fixed Pod for which example

### DIFF
--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -540,7 +540,7 @@ sub check_lib
 
 [version 0.17]
 
- my $path = where($name);
+ my $path = which($name);
 
 Return the path to the first library that matches the given name.
 


### PR DESCRIPTION
Pod had an bad copy/paste for `which` example which is fixed in the pull request.