### PR TITLE
bump ci

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,12 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         cip_tag:
-          - static
           - "5.35"
           - "5.34"
-          - "5.34-alpine3.9"
+          - "5.34-alpine3.11"
           - "5.34-centos7"
-          - "5.34-fedora29"
+          - "5.34-fedora34"
           - "5.32"
           - "5.30"
           - "5.28"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,28 @@
+name: static
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    env:
+      CIP_TAG: static
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bootstrap CIP
+        run: |
+          curl -L https://raw.githubusercontent.com/uperl/cip/main/bin/github-bootstrap | bash
+
+      - name: Build + Test
+        run: |
+          cip script

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FFI::CheckLib ![linux](https://github.com/PerlFFI/FFI-CheckLib/workflows/linux/badge.svg) ![macos](https://github.com/PerlFFI/FFI-CheckLib/workflows/macos/badge.svg) ![cygwin](https://github.com/PerlFFI/FFI-CheckLib/workflows/cygwin/badge.svg)
+# FFI::CheckLib ![static](https://github.com/PerlFFI/FFI-CheckLib/workflows/static/badge.svg) ![linux](https://github.com/PerlFFI/FFI-CheckLib/workflows/linux/badge.svg) ![macos](https://github.com/PerlFFI/FFI-CheckLib/workflows/macos/badge.svg) ![cygwin](https://github.com/PerlFFI/FFI-CheckLib/workflows/cygwin/badge.svg)
 
 Check that a library is available for FFI
 

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ diag          = +FFI::Platypus
 github_user   = PerlFFI
 github_repo   = FFI-CheckLib
 
+workflow = static
 workflow = linux
 workflow = macos
 workflow = cygwin


### PR DESCRIPTION
New version of fedora seems to have a different output format for ld:

```
% /usr/bin/ld -t /usr/lib64/libyaml.so  -o /dev/null -shared
/usr/lib64/libyaml.so
/usr/lib64/libyaml-0.so.2
```