### PR TITLE
Add support for Apple Silicon with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,30 +260,6 @@ probably do some careful consideration before you do so.
 
 This function is not exportable, even on request.
 
-## Extra library paths
-
-### macOS
-
-On macOS platforms with [Homebrew](http://brew.sh) and/or [MacPorts](https://www.macports.org)
-package managers installed, default manager's lib paths will be automatically appended to
-`$system_path`. In case of having both managers installed, Homebrew will appear before.
-
-This behaviour can be overridden using the environment variable `FFI_CHECKLIB_PACKAGE`.
-
-Allowed values are:
-
-- `none`: Won't use either Homebrew path nor MacPorts
-- `homebrew`: Will append the `$(brew --prefix)/lib` to the system paths
-- `macports`: Will append `port` default lib path
-
-A comma separated list is also valid:
-
-```sh
-export FFI_CHECKLIB_PACKAGE=macports,homebrew
-```
-
-Order matters, so in this example, MacPorts' lib path appears before Homebrew's path.
-
 # FAQ
 
 - Why not just use `dlopen`?

--- a/README.md
+++ b/README.md
@@ -260,6 +260,30 @@ probably do some careful consideration before you do so.
 
 This function is not exportable, even on request.
 
+## Extra library paths
+
+### macOS
+
+On macOS platforms with [Homebrew](http://brew.sh) and/or [MacPorts](https://www.macports.org)
+package managers installed, default manager's lib paths will be automatically appended to
+`$system_path`. In case of having both managers installed, Homebrew will appear before.
+
+This behaviour can be overridden using the environment variable `FFI_CHECKLIB_PACKAGE`.
+
+Allowed values are:
+
+- `none`: Won't use either Homebrew path nor MacPorts
+- `homebrew`: Will append the `$(brew --prefix)/lib` to the system paths
+- `macports`: Will append `port` default lib path
+
+A comma separated list is also valid:
+
+```sh
+export FFI_CHECKLIB_PACKAGE=macports,homebrew
+```
+
+Order matters, so in this example, MacPorts' lib path appears before Homebrew's path.
+
 # FAQ
 
 - Why not just use `dlopen`?

--- a/author.yml
+++ b/author.yml
@@ -21,6 +21,9 @@ pod_spelling_system:
     - ppisar
     - UX
     - MRDVT
+    - macOS
+    - Homebrew
+    - MacPorts
 
 
 pod_coverage:

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -108,9 +108,6 @@ else
   die $@ if $@;
   @extra_paths = _darwin_extra_paths() if $os eq 'darwin';
 }
-foreach my $path (@extra_paths) {
-  push @$system_path, $path unless any { $_ eq $path } @$system_path;
-}
 
 our $pattern = [ qr{^lib(.*?)\.so(?:\.([0-9]+(?:\.[0-9]+)*))?$} ];
 our $version_split = qr/\./;
@@ -340,6 +337,10 @@ sub find_lib
   push @path, grep { defined } defined $args{systempath}
     ? @{ $args{systempath} }
     : @$system_path;
+
+  foreach my $extra_path (@extra_paths) {
+    push @path, $extra_path unless any { $_ eq $extra_path } @path;
+  }
 
   my $any = any { $_ eq '*' } @{ $args{lib} };
   my %missing = map { $_ => 1 } @{ $args{lib} };

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -73,7 +73,7 @@ sub _macports_lib_path {
 }
 
 sub _darwin_extra_paths {
-  my $pkg_managers = lc( $ENV{FFI_CHECKLIB_PACKAGE} // 'homebrew,macports' );
+  my $pkg_managers = lc( $ENV{FFI_CHECKLIB_PACKAGE} || 'homebrew,macports' );
   return () if $pkg_managers eq 'none';
   my $supported_managers = {
       homebrew => \&_homebrew_lib_path,

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -74,6 +74,12 @@ else
     \@DynaLoader::dl_library_path;
   };
   die $@ if $@;
+  if($os eq 'darwin' && (qx`command -v brew`)[0])
+  {
+    chomp(my $brew_path = (qx`brew --prefix`)[0]);
+    $brew_path .= '/lib';
+    push @$system_path, $brew_path unless any { $_ eq $brew_path } @$system_path;
+  }
 }
 
 our $pattern = [ qr{^lib(.*?)\.so(?:\.([0-9]+(?:\.[0-9]+)*))?$} ];

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -78,7 +78,7 @@ sub _darwin_extra_paths {
       macports => \&_macports_lib_path
   };
   my @extra_paths = ();
-  foreach my $pkg_manager (split( ',', $pkg_managers )) {
+  foreach my $pkg_manager (split( /,/, $pkg_managers )) {
     if (my $lib_path = $supported_managers->{$pkg_manager}()) {
       push @extra_paths, $lib_path;
     }

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -58,14 +58,16 @@ our $os ||= $^O;
 my $try_ld_on_text = 0;
 
 sub _homebrew_lib_path {
-  return () unless (qx`command -v brew`)[0];
+  require File::Which;
+  return undef unless File::Which::which('brew');
   chomp(my $brew_path = (qx`brew --prefix`)[0]);
   return "$brew_path/lib";
 }
 
 sub _macports_lib_path {
-  my $port_path = (qx`command -v port`)[0];
-  return () unless $port_path;
+  require File::Which;
+  my $port_path = File::Which::which('port');
+  return undef unless $port_path;
   chomp($port_path);
   $port_path =~ s|bin/port|lib|;
   return $port_path;

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -68,7 +68,6 @@ sub _macports_lib_path {
   require File::Which;
   my $port_path = File::Which::which('port');
   return undef unless $port_path;
-  chomp($port_path);
   $port_path =~ s|bin/port|lib|;
   return $port_path;
 }

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -677,6 +677,28 @@ sub system_path
 
 1;
 
+=head1 Extra library paths
+
+=head2 macOS
+
+On macOS platforms with L<Homebrew|http://brew.sh> and/or L<MacPorts|https://www.macports.org>
+installed, their corresponding lib paths will be automatically appended to C<$system_path>.
+In case of having both managers installed, Homebrew will appear before.
+
+This behaviour can be overridden using the environment variable C<FFI_CHECKLIB_PACKAGE>.
+
+Allowed values are:
+
+- C<none>: Won't use either Homebrew's path nor MacPorts
+- C<homebrew>: Will append C<$(brew --prefix)/lib> to the system paths
+- C<macports>: Will append C<port>'s default lib path
+
+A comma separated list is also valid:
+
+ export FFI_CHECKLIB_PACKAGE=macports,homebrew
+
+Order matters. So in this example, MacPorts' lib path appears before Homebrew's path.
+
 =head1 FAQ
 
 =over 4

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -67,7 +67,8 @@ sub _macports_lib_path {
   my $port_path = (qx`command -v port`)[0];
   return () unless $port_path;
   chomp($port_path);
-  return $port_path =~ s|bin/port|lib|r;
+  $port_path =~ s|bin/port|lib|;
+  return $port_path;
 }
 
 sub _darwin_extra_paths {

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -680,9 +680,13 @@ sub system_path
 
 1;
 
-=head1 Extra library paths
+=head1 ENVIRONMENT
 
-=head2 macOS
+L<FFI::CheckLib> responds to these environment variables:
+
+=over 4
+
+=item FFI_CHECKLIB_PACKAGE
 
 On macOS platforms with L<Homebrew|http://brew.sh> and/or L<MacPorts|https://www.macports.org>
 installed, their corresponding lib paths will be automatically appended to C<$system_path>.
@@ -701,6 +705,8 @@ A comma separated list is also valid:
  export FFI_CHECKLIB_PACKAGE=macports,homebrew
 
 Order matters. So in this example, MacPorts' lib path appears before Homebrew's path.
+
+=back
 
 =head1 FAQ
 

--- a/t/ffi_checklib__os_darwin.t
+++ b/t/ffi_checklib__os_darwin.t
@@ -220,7 +220,7 @@ subtest '_cmp' => sub {
 subtest '_darwin_extra_libraries' => sub {
   my $homebrew_lib_path = '/opt/homebrew/lib';
   my $macports_lib_path = '/opt/local/lib';
-  my $mock = Test2::V0::mock 'FFI::CheckLib';
+  my $mock = mock 'FFI::CheckLib';
   $mock->override(
       _homebrew_lib_path => sub {$homebrew_lib_path},
       _macports_lib_path => sub {$macports_lib_path}

--- a/t/ffi_checklib__os_darwin.t
+++ b/t/ffi_checklib__os_darwin.t
@@ -217,4 +217,64 @@ subtest '_cmp' => sub {
 
 };
 
+subtest '_darwin_extra_libraries' => sub {
+  my $homebrew_lib_path = '/opt/homebrew/lib';
+  my $macports_lib_path = '/opt/local/lib';
+  my $mock = Test2::V0::mock 'FFI::CheckLib';
+  $mock->override(
+      _homebrew_lib_path => sub {$homebrew_lib_path},
+      _macports_lib_path => sub {$macports_lib_path}
+  );
+
+  subtest 'default' => sub {
+    local %ENV = %ENV;
+    delete $ENV{FFI_CHECKLIB_PACKAGE};
+    is(
+        [ FFI::CheckLib::_darwin_extra_paths() ],
+        [ $homebrew_lib_path, $macports_lib_path ],
+        'homebrew and macports lib paths added'
+    );
+  };
+
+  subtest 'none' => sub {
+    local %ENV = %ENV;
+    $ENV{FFI_CHECKLIB_PACKAGE} = 'NONE';
+    is(
+        [ FFI::CheckLib::_darwin_extra_paths() ],
+        [],
+        'None extra lib paths added'
+    );
+  };
+
+  subtest 'homebrew' => sub {
+    local %ENV = %ENV;
+    $ENV{FFI_CHECKLIB_PACKAGE} = 'Homebrew';
+    is(
+        [ FFI::CheckLib::_darwin_extra_paths() ],
+        [ $homebrew_lib_path ],
+        'homebrew lib path added'
+    );
+  };
+
+  subtest 'macports' => sub {
+    local %ENV = %ENV;
+    $ENV{FFI_CHECKLIB_PACKAGE} = 'MacPorts';
+    is(
+        [ FFI::CheckLib::_darwin_extra_paths() ],
+        [ $macports_lib_path ],
+        'macports lib path loaded'
+    );
+  };
+
+  subtest 'macports,homebrew' => sub {
+    local %ENV = %ENV;
+    $ENV{FFI_CHECKLIB_PACKAGE} = 'macports,homebrew';
+    is(
+        [ FFI::CheckLib::_darwin_extra_paths() ],
+        [ $macports_lib_path, $homebrew_lib_path ],
+        'macports and homebrew lib paths added (order matters)'
+    );
+  };
+};
+
 done_testing;


### PR DESCRIPTION
With Apple Silicon, Homebrew changed the default installation path from `/usr/local` to `/opt/homebrew`.

This new path is not included by default in the system libraries, so some modules fail looking for libraries installed with Homebrew under Apple Silicon machines.

This commit adds support for adding Homebrew lib path to make then available