### PR TITLE
prefer alien libraries over system

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - [ BREAKING CHANGE ]
+    If the alien option is provided, the libraries provided by aliens will be
+    preferred over the system libraries (gh#47, gh#48)
 
 0.29      2022-09-10 01:46:05 -0600
   - Handle Windows DLLs using underscores instead of dashes in version

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Arguments are key value pairs with these keys:
     doesn't look like a module name or if it does not provide a `dynamic_libs`
     method (which is implemented by all [Alien::Base](https://metacpan.org/pod/Alien::Base) subclasses).
 
+    \[version 0.30\]
+    \[breaking change\]
+
+    Starting with version 0.30, libraries provided by [Alien](https://metacpan.org/pod/Alien)s is preferred
+    over the system libraries.  The original thinking was that you want to
+    prefer the system libraries because they are more likely to get patched
+    with regular system updates.  Unfortunately, the reason a module needs to
+    install an Alien is likely because the system library is not new enough,
+    so we now prefer the [Alien](https://metacpan.org/pod/Alien)s instead.
+
 ## assert\_lib
 
 ```

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -250,6 +250,16 @@ only.  This module I<will> still throw an exception, if the L<Alien>
 doesn't look like a module name or if it does not provide a C<dynamic_libs>
 method (which is implemented by all L<Alien::Base> subclasses).
 
+[version 0.30]
+[breaking change]
+
+Starting with version 0.30, libraries provided by L<Alien>s is preferred
+over the system libraries.  The original thinking was that you want to
+prefer the system libraries because they are more likely to get patched
+with regular system updates.  Unfortunately, the reason a module needs to
+install an Alien is likely because the system library is not new enough,
+so we now prefer the L<Alien>s instead.
+
 =back
 
 =cut
@@ -302,7 +312,7 @@ sub find_lib
 
   delete $missing{'*'};
 
-  alien: foreach my $alien (@{ $args{alien} })
+  alien: foreach my $alien (reverse @{ $args{alien} })
   {
     unless($alien =~ /^([A-Za-z_][A-Za-z_0-9]*)(::[A-Za-z_][A-Za-z_0-9]*)*$/)
     {
@@ -322,7 +332,7 @@ sub find_lib
         croak "Alien $alien doesn't provide a dynamic_libs method";
       }
     }
-    push @path, [$alien->dynamic_libs];
+    unshift @path, [$alien->dynamic_libs];
   }
 
   foreach my $path (@path)


### PR DESCRIPTION
From the documentation:

Starting with version 0.30, libraries provided by [Alien](https://metacpan.org/pod/Alien)s is preferred over the system libraries.  The original thinking was that you want to prefer the system libraries because they are more likely to get patched with regular system updates.  Unfortunately, the reason a module needs to install an Alien is likely because the system library is not new enough, so we now prefer the [Alien](https://metacpan.org/pod/Alien)s instead.

this is for #47 and https://github.com/uperl/Archive-Libarchive/issues/40